### PR TITLE
Fix for dns v3.

### DIFF
--- a/Network/DNS/Cache/Types.hs
+++ b/Network/DNS/Cache/Types.hs
@@ -4,7 +4,6 @@ module Network.DNS.Cache.Types (
   , Value(..)
   , Entry
   , Result(..)
-  , TTL
   , HostAddress
   , Domain
   , DNSError(..)
@@ -26,8 +25,6 @@ data Value = Value (UArray Int HostAddress) (IORef Int)
 
 instance Show Value where
     show (Value a _) = show a
-
-type TTL = Int
 
 -- | Information of positive result.
 data Result =

--- a/concurrent-dns-cache.cabal
+++ b/concurrent-dns-cache.cabal
@@ -24,7 +24,7 @@ Library
                       , async
                       , bytestring >= 0.10.4.0
                       , containers
-                      , dns < 3
+                      , dns >= 3
                       , iproute
                       , lifted-base
                       , monad-control
@@ -45,7 +45,7 @@ Executable main
                       , bytestring >= 0.10.4.0
                       , concurrent-dns-cache
                       , containers
-                      , dns < 3
+                      , dns >= 3
                       , iproute
                       , lifted-base
                       , monad-control
@@ -64,7 +64,7 @@ Test-Suite spec
   Build-Depends:        base >= 4 && < 5
                       , async
                       , concurrent-dns-cache
-                      , dns < 3
+                      , dns >= 3
                       , hspec
 
 Source-Repository head


### PR DESCRIPTION
Small fix for `concurrent-dns-cache` to work with `dns` >= 3.0